### PR TITLE
Fix excessive BGP RIB updates

### DIFF
--- a/pkg/bgp/bgp.go
+++ b/pkg/bgp/bgp.go
@@ -14,9 +14,12 @@ import (
 // and it will manage the whole add/remove/change process.
 type Controller interface {
 
+	// Get returns the addresses currently in the BGP RIB
+	Get(ctx context.Context) ([]string, error)
+
 	// Set receives a list of ip addresses and performs the necessary
 	// steps to configure each address in BGP.
-	Set(ctx context.Context, addresses []string) error
+	Set(ctx context.Context, addresses, configuredAddresses []string) error
 
 	// Teardown removes all addresses from BGP.
 	// Perhaps this will never be applied.
@@ -28,9 +31,52 @@ type GoBGPDController struct {
 	logger      logrus.FieldLogger
 }
 
-func (g *GoBGPDController) Set(ctx context.Context, addresses []string) error {
+func (g *GoBGPDController) Get(ctx context.Context) ([]string, error) {
+	configuredAddrs := []string{}
+
+	args := []string{"global", "rib", "-a", "ipv4"}
+	cmd := exec.CommandContext(ctx, g.commandPath, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return configuredAddrs, fmt.Errorf("could not return list of configured addresses from gobgo: %v", err)
+	}
+
+	return parseRIBOutput(out), nil
+}
+
+func parseRIBOutput(output []byte) []string {
+	outputAsList := strings.Split(string(output), "\n")
+	addresses := []string{}
+	// start at 1 to skip columnar format line
+	for i := 1; i < len(outputAsList); i++ {
+		out := outputAsList[i]
+		fields := strings.Fields(out)
+		if len(fields) > 2 {
+			trimCidr := strings.Replace(fields[1], "/32", "", 1)
+			addresses = append(addresses, trimCidr)
+		}
+	}
+	return addresses
+}
+
+func (g *GoBGPDController) Set(ctx context.Context, addresses, configuredAddresses []string) error {
+	// quick check to see if this is already configured. If so, no need to push
+	// another network update
+	toAdd := []string{}
+	for _, addr := range addresses {
+		var found bool
+		for _, configured := range configuredAddresses {
+			if addr == configured {
+				found = true
+				break
+			}
+		}
+		if !found {
+			toAdd = append(toAdd, addr)
+		}
+	}
 	// $PATH/gobgp global rib -a ipv4 add 10.54.213.148/32
-	for _, address := range addresses {
+	for _, address := range toAdd {
 		cidr := address + "/32"
 		g.logger.Debugf("Advertising route to %s", cidr)
 		args := []string{"global", "rib", "-a", "ipv4", "add", cidr}

--- a/pkg/bgp/bgp_test.go
+++ b/pkg/bgp/bgp_test.go
@@ -1,0 +1,34 @@
+package bgp
+
+import (
+	"reflect"
+	"testing"
+)
+
+/*
+	example output
+*/
+var output = []byte(`Network              Next Hop             AS_PATH              Age        Attrs
+*> 10.131.153.120/32    0.0.0.0                                   00:00:21   [{Origin: ?}]
+*> 10.131.153.121/32    0.0.0.0                                   00:00:21   [{Origin: ?}]
+*> 10.131.153.122/32    0.0.0.0                                   00:00:21   [{Origin: ?}]
+*> 10.131.153.123/32    0.0.0.0                                   00:00:21   [{Origin: ?}]
+*> 10.131.153.124/32    0.0.0.0                                   00:00:21   [{Origin: ?}]
+*> 10.131.153.125/32    0.0.0.0                                   00:00:21   [{Origin: ?}]
+`)
+
+func TestParseBGPOutput(t *testing.T) {
+	shouldEqual := []string{
+		"10.131.153.120",
+		"10.131.153.121",
+		"10.131.153.122",
+		"10.131.153.123",
+		"10.131.153.124",
+		"10.131.153.125",
+	}
+	outParsed := parseRIBOutput(output)
+
+	if !reflect.DeepEqual(shouldEqual, outParsed) {
+		t.Fatalf("outputs were not equal. expected %v, saw %v:", shouldEqual, outParsed)
+	}
+}

--- a/pkg/bgp/worker.go
+++ b/pkg/bgp/worker.go
@@ -218,6 +218,11 @@ func (b *bgpserver) configure() error {
 		return err
 	}
 
+	configuredAddrs, err := b.bgp.Get(b.ctx)
+	if err != nil {
+		return err
+	}
+
 	// Do something BGP-ish with VIPs from configmap
 	// This only adds, and never removes, VIPs
 	logger.Debug("applying bgp settings")
@@ -225,7 +230,7 @@ func (b *bgpserver) configure() error {
 	for ip, _ := range b.config.Config {
 		addrs = append(addrs, string(ip))
 	}
-	err = b.bgp.Set(b.ctx, addrs)
+	err = b.bgp.Set(b.ctx, addrs, configuredAddrs)
 	if err != nil {
 		return err
 	}
@@ -259,11 +264,16 @@ func (b *bgpserver) configure6() error {
 	}
 
 	logger.Debug("setting up bgp")
+	configuredAddrs, err := b.bgp.Get(b.ctx)
+	if err != nil {
+		return err
+	}
+
 	addrs := []string{}
 	for ip, _ := range b.config.Config6 {
 		addrs = append(addrs, string(ip))
 	}
-	err = b.bgp.Set(b.ctx, addrs)
+	err = b.bgp.Set(b.ctx, addrs, configuredAddrs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Minimize the number of times we run the command `gobgp rib add <addr>`. Previously, this command was ran every 30 seconds, resulting in drop / adds of paths that should have just not been manipulated:

`Feb 18 22:01:38 anv1-dev-dev-ravel-5001-7--<redacted> rkt[47350]: [8288927.918604] gobgpd[6]: time="2020-02-18T22:01:38Z" level=debug msg="Implicit withdrawal of old path, since we have learned new path from the same peer" Key=<redacted>/32 Path="{ <redacted>/32 | src: local, nh: 0.0.0.0 }" Topic=Table
Feb 18 22:01:38 anv1-dev-dev-ravel-5001-7--<redacted> rkt[47350]: [8288927.919180] gobgpd[6]: time="2020-02-18T22:01:38Z" level=debug msg="sent update" Key=<redacted> State=BGP_FSM_ESTABLISHED Topic=Peer attributes="[{Origin: ?} 65014 {Nexthop: <redacted>}]" nlri="[<redacted>/32]" withdrawals="[]"`

`Feb 18 22:01:38 anv1-dev-dev-ravel-5001-7--<redacted> rkt[47350]: [8288927.919438] gobgpd[6]: time="2020-02-18T22:01:38Z" level=debug msg="sent update" Key=<redacteed> State=BGP_FSM_ESTABLISHED Topic=Peer attributes="[{Origin: ?} 65014 {Nexthop: <redacted>}]" nlri="[<redacted>/32]" withdrawals="[]"`

This PR checks what is in the table, checks our desired state, and only adds new ones that are not present.

A subsequent PR will be needed to do the same thing, but for v6 addresses, once that branch is merged.