### PR TITLE
Feature/mode env flag

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/exec"
 	"reflect"
 	"strconv"
 	"strings"
@@ -51,6 +55,9 @@ type Config struct {
 	DefaultListener DefaultListenerConfig
 
 	BGP BGPConfig
+
+	FlagModeEnv     bool
+	EnvFileLocation string
 }
 
 func (c *Config) Invalid() error {
@@ -253,6 +260,64 @@ func processReflection(v reflect.Value, i int) (string, string, string, string, 
 	return name, typ, defaultVal, tag, value
 }
 
+func (c *Config) retrieveNodeConfig() error {
+	if c.FlagModeEnv && c.EnvFileLocation == "" {
+		return fmt.Errorf("in flag-mode-env, you need to specify the location that the file etc/environment is located in the deployment volume mount")
+	}
+
+	env := map[string]string{}
+
+	envFile, err := ioutil.ReadFile(c.EnvFileLocation)
+	if err != nil {
+		return fmt.Errorf("error retrieving environment variables from node: %v", err)
+	}
+
+	envFileLines := bytes.Split(envFile, []byte("\n"))
+
+	for _, line := range envFileLines {
+		if len(line) == 0 {
+			continue
+		}
+
+		lineSpl := strings.Split(string(line), "=")
+		if len(lineSpl) < 2 {
+			// ignore lines without = present
+			continue
+		}
+
+		// this case accounts for vars that may be in the format VAR=foo=bar=zarb
+		// and recreates them in this format in the map
+		env[lineSpl[0]] = strings.Join(lineSpl[1:], "=")
+	}
+
+	// now set the variables on the config. The c.Validate() method is called
+	// after this and will verify them outside of this method
+	// these use the same environment var names found in systemd files for RS
+	c.NodeName = env["HOST_IP"]
+	c.ConfigKey = env["SUBNET_KEY"]
+	c.Net.PrimaryIP = env["HOST_IP"]
+	c.Net.Gateway = env["HOST_GATEWAY"]
+	c.DefaultListener.Service = fmt.Sprintf("rdei-system/unicorns-%s:http", env["HOST_SECURITY_ZONE"])
+
+	// lastly, fetch the primary interface name which is not provided in env
+	// but fetched at rkt init on compute nodes via ip route get 1 | head -1 | cut -d' ' -f5
+	// running these pods with hostnetwork=true so we don't get a container virtual interface
+	cmd := exec.CommandContext(context.Background(), "ip", "route", "get", "1")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to fetch primary interface: %v", err.Error())
+	}
+
+	s := bytes.Split(b, []byte(" "))
+	if len(s) < 5 {
+		return fmt.Errorf("not enough fields found for ip command: expected at least 5, saw %d", len(s))
+	}
+
+	c.Net.Interface = string(s[4])
+
+	return nil
+}
+
 // WARNING: This will panic if we have any non-string fields in the IPVS struct
 // because we control the inputs (the type of fields on the struct and the tags themselves) this sort of risky business is fine
 func setValue(name string, valueOR string, reflectVal reflect.Value) {
@@ -332,6 +397,8 @@ func NewConfig(flags *pflag.FlagSet) *Config {
 	config.DefaultListener.Port = viper.GetInt("auto-configure-port")
 
 	config.BGP.Binary = viper.GetString("bgp-bin")
+
+	config.FlagModeEnv = viper.GetBool("flag-mode-env")
 
 	return config
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -198,7 +198,6 @@ func (i *IPVSConfig) WriteToNode() error {
 	for n := 0; n < reflectVal.NumField(); n++ {
 		// create reflect.Values and extract the name of field, ipvsTag
 		_, _, _, tag, value := processReflection(reflectVal, n)
-		fmt.Printf("setting value %s=%s\n", tag, value.String())
 		err := i.SetSysctl(tag, value.String())
 		if err != nil {
 			return err

--- a/cmd/kube2ipvs.go
+++ b/cmd/kube2ipvs.go
@@ -86,6 +86,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("forced-reconfigure", false, "Reconfigure happens every 10 minutes")
 	rootCmd.PersistentFlags().Bool("ipvs-weight-override", false, "set all IPVS wrr weights to 1 regardless")
 	rootCmd.PersistentFlags().Bool("ipvs-ignore-node-cordon", false, "ignore cordoned flag when determining whether a node is an eligible backend")
+	rootCmd.PersistentFlags().Bool("flag-mode-env", false, "for a realserver deployment only. retrieve the values of the following flags from the node environment: --nodename, --compute-iface, --config-key, --primary-ip, --gateway, --auto-configure-service. If these values are provided via an argument, they will be OVERWRITTEN unless the env value on the node is empty. This requires the volume mount /etc present on the deployment")
 
 	rootCmd.PersistentFlags().String("iptables-chain", "RAVEL", "The name of the iptables chain to use.")
 	rootCmd.PersistentFlags().Int("failover-timeout", 1, "number of seconds for the realserver to wait before reconfiguring itself")
@@ -148,6 +149,7 @@ Mode "ipvs" will result in pod ip addresses being added to the ipvs configuraton
 	viper.BindPFlag("forced-reconfigure", rootCmd.PersistentFlags().Lookup("forced-reconfigure"))
 	viper.BindPFlag("ipvs-weight-override", rootCmd.PersistentFlags().Lookup("ipvs-weight-override"))
 	viper.BindPFlag("ipvs-ignore-node-cordon", rootCmd.PersistentFlags().Lookup("ipvs-ignore-node-cordon"))
+	viper.BindPFlag("flag-mode-env", rootCmd.PersistentFlags().Lookup("flag-mode-env"))
 }
 
 func main() {

--- a/cmd/realserver.go
+++ b/cmd/realserver.go
@@ -36,6 +36,12 @@ are missing from the configuration.`,
 			config := NewConfig(cmd.Flags())
 			logger.Debugf("got config %+v", config)
 
+			if config.FlagModeEnv {
+				if err := config.retrieveNodeConfig(); err != nil {
+					return err
+				}
+			}
+
 			// validate flags
 			if err := config.Invalid(); err != nil {
 				return err

--- a/pkg/bgp/worker.go
+++ b/pkg/bgp/worker.go
@@ -118,7 +118,6 @@ func (b *bgpserver) cleanup(ctx context.Context) error {
 func (b *bgpserver) setup() error {
 	b.logger.Debugf("Enter func (b *bgpserver) setup()\n")
 	defer b.logger.Debugf("Exit func (b *bgpserver) setup()\n")
-	var err error
 
 	ctxWatch, cxlWatch := context.WithCancel(b.ctx)
 	b.cxlWatch = cxlWatch


### PR DESCRIPTION
add a flag that instructs realservers to collect certain flags from the host node. This allows the realserver to run as a daemonset - in rkt, each node has a unique set of environment variables that are computed on systemd init via bash, which can't be implemented in a Kubernetes daemonset.

This change will allow users to set an env-mode flag as well as the location of the environment file that contains all the vars scraped up by rkt init, which requires a volume mount in the deployment