### PR TITLE
add symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,6 @@ COPY --from=0 /go/src/github.com/comcast/ravel/ravel /bin/
 COPY --from=0 /go/src/github.com/comcast/ravel/gobgp /bin/
 COPY --from=0 /go/src/github.com/comcast/ravel/gobgpd /bin/
 RUN chmod ugo+x /bin/gobgp
+RUN ln -s /bin/ravel /bin/kube2ipvs
 
 ENTRYPOINT ["/bin/ravel"]


### PR DESCRIPTION
For backwards compatibility, we are adding a symlink to old binary name in order to facilitate  ease of transitioning in mixed envs. This enables the binary to be run as `kube2ipvs` or `ravel`