### PR TITLE
remove erroneous return in periodic()

### DIFF
--- a/pkg/bgp/worker.go
+++ b/pkg/bgp/worker.go
@@ -292,7 +292,6 @@ func (b *bgpserver) periodic() {
 			if err := b.configure6(); err != nil {
 				b.metrics.Reconfigure("critical", time.Now().Sub(start))
 				b.logger.Errorf("unable to apply mandatory ipv6 reconfiguration. %v", err)
-				return
 			}
 
 			b.metrics.Reconfigure("complete", time.Now().Sub(start))


### PR DESCRIPTION
This fixes an erroneous return in the ravel master `periodic()` method that caused LVS rules to stop being written. 

Observed that after a long period of time new LVS rules were not being written. Logs yielded this line:
```
36137 May 21 08:41:18 anvil-vpes-integration-ravel--10-54-213-178 rkt[32007]: [1693785.754708] ravel-director[6]: time      ="2020-05-21T08:41:18Z" level=error msg="unable to apply mandatory ipv6 reconfiguration. unable to configure ipvs with error exit status 255" s=rdei-lb
```

Time delta between this and beginning of logs (`May 17 20:34:45`) is about 84 hours which explains why this sort of thing goes unnoticed for long periods of time. Exit status does not explain anything useful about the error, but at any rate we should log an error and register it with prometheus, then try again, not shut down. 