### PR TITLE
fix K8ENG-4596

### DIFF
--- a/pkg/util/iptables.go
+++ b/pkg/util/iptables.go
@@ -403,7 +403,7 @@ func (runner *Runner) iptablesCommand() string {
 	}
 }
 
-func (runner *Runner) isNFT() bool {
+func (runner *Runner) IsNFT() bool {
 	return strings.Contains(runner.iptablesCommand(), "-nft")
 }
 


### PR DESCRIPTION
ravel fails when running iptables-nft-restore

 

```

Jun 25 22:31:31 anv2-2006-7-rdei-dev-01--10-27-50-42 nerdctl[3945511]: IPTABLES Restore iptables-nft-restore [-T nat --counters]
Jun 25 22:31:31 anv2-2006-7-rdei-dev-01--10-27-50-42 nerdctl[3945511]: time="2024-06-25T22:31:31Z" level=error msg="realserver: error applying rules. writing erroneous rule change to /tmp/realserver-ruleset-err for debugging" s=rdei-lb
Jun 25 22:31:31 anv2-2006-7-rdei-dev-01--10-27-50-42 nerdctl[3945511]: time="2024-06-25T22:31:31Z" level=info msg="realserver: IPVS reconfiguration took 18.120799ms" s=rdei-lb
Jun 25 22:31:31 anv2-2006-7-rdei-dev-01--10-27-50-42 nerdctl[3945511]: time="2024-06-25T22:31:31Z" level=error msg="realserver: unable to apply ipv4 configuration, iptables-nft-restore - exit status 2 (iptables-nft-restore v1.8.8 (nf_tables): Bad mode \"random#\"\nError occurred at line: 430\nTry `iptables-nft-restore -h' or 'iptables-nft-restore --help' for more information.\n)" s=rdei-lb